### PR TITLE
Add Mark Headd to the list for US civic tech folks

### DIFF
--- a/_people/mark-headd.yml
+++ b/_people/mark-headd.yml
@@ -1,0 +1,7 @@
+---
+name: "Mark Headd"
+account: "@mheadd@mastodon.social"
+link: "https://mastodon.social/@mheadd"
+image: "https://files.mastodon.social/accounts/avatars/109/246/188/511/613/560/original/b9cd0d8eb94c98f3.jpeg"
+country: US
+---


### PR DESCRIPTION
Adding my name (Mark Headd) to the list of civic tech practitioners in the US.